### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ librosa==0.8.0
 matplotlib==3.3.1
 numpy==1.21.6
 phonemizer==2.2.1
-scipy==1.5.2
-tensorboard==2.3.0
+scipy==1.7.3
+tensorboard==2.8.0
 Unidecode==1.1.1
 pyopenjtalk==0.2.0
 pypinyin


### PR DESCRIPTION
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tensorflow 2.8.2+zzzcolab20220719082949 requires tensorboard<2.9,>=2.8, but you have tensorboard 2.3.0 which is incompatible.
pymc3 3.11.5 requires scipy<1.8.0,>=1.7.3, but you have scipy 1.5.2 which is incompatible.